### PR TITLE
Revert axios-cache-interceptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@t3-oss/env-nextjs": "^0.12.0",
     "@tanstack/react-table": "^8.21.2",
     "axios": "^1.8.3",
-    "axios-cache-interceptor": "^1.7.0",
     "bcrypt": "^5.1.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,9 +55,6 @@ importers:
       axios:
         specifier: ^1.8.3
         version: 1.8.3
-      axios-cache-interceptor:
-        specifier: ^1.7.0
-        version: 1.7.0(axios@1.8.3)
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1
@@ -1663,15 +1660,6 @@ packages:
       }
     engines: { node: '>=4' }
 
-  axios-cache-interceptor@1.7.0:
-    resolution:
-      {
-        integrity: sha512-SP/QpCApakyGncF7ttyGsKt0CK5XG+tsdGAGTumHTzO1acnn9v7bd1XK1LiIcyXp46mlKS8j5iwvhNyFFWUKZQ==,
-      }
-    engines: { node: '>=12' }
-    peerDependencies:
-      axios: ^1
-
   axios@1.8.3:
     resolution:
       {
@@ -1730,12 +1718,6 @@ packages:
         integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==,
       }
     engines: { node: '>=10.16.0' }
-
-  cache-parser@1.2.5:
-    resolution:
-      {
-        integrity: sha512-Md/4VhAHByQ9frQ15WD6LrMNiVw9AEl/J7vWIXw+sxT6fSOpbtt6LHTp76vy8+bOESPBO94117Hm2bIjlI7XjA==,
-      }
 
   call-bind-apply-helpers@1.0.2:
     resolution:
@@ -2314,12 +2296,6 @@ packages:
     resolution:
       {
         integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
-      }
-
-  fast-defer@1.1.8:
-    resolution:
-      {
-        integrity: sha512-lEJeOH5VL5R09j6AA0D4Uvq7AgsHw0dAImQQ+F3iSyHZuAxyQfWobsagGpTcOPvJr3urmKRHrs+Gs9hV+/Qm/Q==,
       }
 
   fast-glob@3.3.1:
@@ -3383,12 +3359,6 @@ packages:
         integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
       }
     engines: { node: '>=0.10.0' }
-
-  object-code@1.3.3:
-    resolution:
-      {
-        integrity: sha512-/Ds4Xd5xzrtUOJ+xJQ57iAy0BZsZltOHssnDgcZ8DOhgh41q1YJCnTPnWdWSLkNGNnxYzhYChjc5dgC9mEERCA==,
-      }
 
   object-inspect@1.13.4:
     resolution:
@@ -5423,13 +5393,6 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios-cache-interceptor@1.7.0(axios@1.8.3):
-    dependencies:
-      axios: 1.8.3
-      cache-parser: 1.2.5
-      fast-defer: 1.1.8
-      object-code: 1.3.3
-
   axios@1.8.3:
     dependencies:
       follow-redirects: 1.15.9
@@ -5468,8 +5431,6 @@ snapshots:
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
-
-  cache-parser@1.2.5: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -5951,8 +5912,6 @@ snapshots:
       strip-final-newline: 3.0.0
 
   fast-deep-equal@3.1.3: {}
-
-  fast-defer@1.1.8: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -6551,8 +6510,6 @@ snapshots:
   oauth4webapi@3.3.1: {}
 
   object-assign@4.1.1: {}
-
-  object-code@1.3.3: {}
 
   object-inspect@1.13.4: {}
 

--- a/src/components/ui/dashboard/products/products-table.tsx
+++ b/src/components/ui/dashboard/products/products-table.tsx
@@ -22,14 +22,14 @@ export async function ProductsTable({
   let isError = false;
 
   try {
-    const data = await db.products.get({ page: 0, name: search });
+    const data = await db.products.get();
     products = data.content;
 
     // Since query functionalities are still limited in the backend
     // then manually get all products:
     const promises: ReturnType<typeof db.products.get>[] = [];
     for (let i = 1; i < data.totalPages; i++)
-      promises.push(db.products.get({ page: i, name: search }));
+      promises.push(db.products.get({ page: i }));
     (await Promise.all(promises)).forEach(({ content }) =>
       products.push(...content)
     );

--- a/src/lib/db/instance.ts
+++ b/src/lib/db/instance.ts
@@ -1,67 +1,22 @@
 import { env } from '@/data/env/server';
-import {
-  buildMemoryStorage,
-  CacheUpdater,
-  MemoryStorage,
-  setupCache,
-} from 'axios-cache-interceptor';
-import Axios from 'axios';
+import axios from 'axios';
 
-/**
- * Since I implemented a custom cache invalidation and "importing"
- * the instance of the axios cache creates multiple copies of it,
- * I instead made it the underlying storage globally available.
- *
- * This is in no way will be in the final production code.
- * Once the backend has the features I need, I will remove this.
- */
-declare global {
-  // eslint-disable-next-line no-var
-  var storage: MemoryStorage;
-}
-
-globalThis.storage = globalThis.storage ?? buildMemoryStorage(false, 1000 * 10); // 10 minutes
-
-const axios = Axios.create({
+const instance = axios.create({
   baseURL: env.DB_BASE_URL,
 });
 
-const instance = setupCache(axios, { storage });
-
 if (env.NODE_ENV === 'development') {
   instance.interceptors.request.use((request) => {
-    console.log(`[REQ]: ${request.method?.toUpperCase()} ${request.url}`);
+    console.log(
+      `[DEV] Request: ${request.method?.toUpperCase()} ${request.url}`
+    );
     return request;
   });
 
   instance.interceptors.response.use((response) => {
-    console.log(
-      `${response.cached ? '[CACHED]' : ''}[RES]: ${response.config.url}`
-    );
+    // console.log(`[DEV] Response (${response.config.url}):`, response.data);
     return response;
   });
 }
-
-export const createCacheId = (keys: (string | number)[]): string =>
-  keys.join('-');
-
-export const createInvalidateUpdateCache = async <R, D>(
-  ...idsKeys: (string | number)[][]
-): Promise<CacheUpdater<R, D>> => {
-  const cache: Record<string, 'delete'> = {};
-  const cachedIds = Object.keys(storage.data);
-
-  for (const idKeys of idsKeys) {
-    const idToInvalidate = createCacheId(idKeys);
-    for (const cachedId of cachedIds) {
-      if (!cachedId.startsWith(idToInvalidate)) continue;
-      cache[cachedId] = 'delete';
-      console.log('REMOVE ID:', cachedId);
-      delete storage.data[idToInvalidate];
-    }
-  }
-
-  return cache;
-};
 
 export default instance;

--- a/src/lib/db/products.ts
+++ b/src/lib/db/products.ts
@@ -1,21 +1,15 @@
-'use server';
-
 import { Product, CreateProductDTO, UpdateProductDTO } from '@/types/db';
-import instance, {
-  createCacheId,
-  createInvalidateUpdateCache,
-} from './instance';
+import instance from './instance';
+import { AxiosResponse } from 'axios';
 
 const route = `products`;
 
 export const get = async ({
   page,
-  name,
   sortDirection,
   dataType,
 }: {
   page?: number;
-  name?: string;
   sortDirection?: 'asc' | 'desc';
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   dataType?: keyof Pick<Product, 'name' | 'sellingPrice' | 'category'> | {};
@@ -32,36 +26,25 @@ export const get = async ({
   const params = new URLSearchParams();
 
   params.set('page', page?.toString() || '0');
-  if (name) params.set('name', name);
   params.set('sortDirection', sortDirection ?? 'asc');
   params.set('dataType', (dataType as string | undefined) || 'name');
 
-  const response = await instance.get(`/${route}/?${params.toString()}`, {
-    id: createCacheId(['products', params.toString()]),
-  });
-  return structuredClone(response.data);
+  const response = await instance.get(`/${route}/?${params.toString()}`);
+
+  return response.data;
 };
 
 export const getById = async (id: number): Promise<Product> => {
-  const response = await instance.get<Product>(`/${route}/id/?id=${id}`, {
-    id: createCacheId(['product', id]),
-  });
+  const response = await instance.get<Product>(`/${route}/id/?id=${id}`);
   return response.data;
 };
 
 export const create = async (data: CreateProductDTO): Promise<string> => {
   const response = await instance.post<
     string,
+    AxiosResponse,
     CreateProductDTO & Pick<Product, 'stocks'>
-  >(
-    `/${route}/add`,
-    { ...data, stocks: [] },
-    {
-      cache: {
-        update: await createInvalidateUpdateCache(['products']),
-      },
-    }
-  );
+  >(`/${route}/add`, { ...data, stocks: [] });
   return response.data;
 };
 
@@ -69,26 +52,14 @@ export const update = async (
   id: number,
   data: UpdateProductDTO
 ): Promise<string> => {
-  const response = await instance.put<string, UpdateProductDTO>(
+  const response = await instance.put<string, AxiosResponse, UpdateProductDTO>(
     `/${route}/id/?id=${id}`,
-    data,
-    {
-      cache: {
-        update: await createInvalidateUpdateCache(
-          ['products'],
-          ['product', id]
-        ),
-      },
-    }
+    data
   );
   return response.data;
 };
 
 export const deleteById = async (id: number): Promise<string> => {
-  const response = await instance.delete<string>(`/${route}/id/?id=${id}`, {
-    cache: {
-      update: await createInvalidateUpdateCache(['products'], ['product', id]),
-    },
-  });
+  const response = await instance.delete<string>(`/${route}/id/?id=${id}`);
   return response.data;
 };


### PR DESCRIPTION
## Description
Axios cache interceptor is an interceptor for axios, a data-fetching library. An interceptor "intercepts" requests and responses, in this case, the axios cache interceptor package intercepts these requests/responses to cache them.

Since the package doesn't really implement multiple keys caching, I had to create functions for it which does a conversion of a multikeys caching to a single string. I also figured out while trying to implement multikeys caching that another instances of axios cache interceptors were being created. This is due to the importation of modules. To work around it, I had to create a global variable with `globalThis` to make the storage global across modules import.

All in all, it was a hacky solution and I find it reinventing the wheel honestly. There were already other options: either use Tanstack Query or the canary version of NextJS with DynamicIO.

I don't really lean on Tanstack Query since it handles caching on the client and since NextJS is an amalgamation of both client and server, it'd be better if I cache on the server. It saves a lot of requests too with multiple users.

In any case, I've already been exposed on DynamicIO but I was skeptical to using canary versions. However, since this is more of a test project and reinventing the wheel causes a lot of headaches, I will opt out to using the canary version and remove the axios cache interceptors.

I am documenting this revert by creating this PR to infer back to it if I ever need.